### PR TITLE
Support service stats

### DIFF
--- a/AzureSearchEmulator/Controllers/ServiceStatsController.cs
+++ b/AzureSearchEmulator/Controllers/ServiceStatsController.cs
@@ -1,0 +1,84 @@
+using AzureSearchEmulator.Models;
+using AzureSearchEmulator.Repositories;
+using Microsoft.AspNetCore.Mvc;
+
+namespace AzureSearchEmulator.Controllers;
+
+[ApiController]
+[Route("servicestats")]
+public class ServiceStatsController(ISearchIndexRepository searchIndexRepository) : ControllerBase
+{
+    [HttpGet]
+    public async Task<IActionResult> Get()
+    {
+        var indexes = new List<SearchIndex>();
+        await foreach (var index in searchIndexRepository.GetAll())
+        {
+            indexes.Add(index);
+        }
+        
+        var stats = new Dictionary<string, object>
+        {
+            ["@odata.context"] = $"{Request.Scheme}://{Request.Host}/$metadata#Microsoft.Azure.Search.V2025_05_01_Preview.ServiceStatistics",
+            ["counters"] = new
+            {
+                documentCount = new
+                {
+                    usage = 0,
+                    quota = (long?)null
+                },
+                indexesCount = new
+                {
+                    usage = indexes.Count,
+                    quota = 15
+                },
+                indexersCount = new
+                {
+                    usage = 0,
+                    quota = 15
+                },
+                dataSourcesCount = new
+                {
+                    usage = 0,
+                    quota = 15
+                },
+                storageSize = new
+                {
+                    usage = 0L,
+                    quota = 16106127360L
+                },
+                synonymMaps = new
+                {
+                    usage = 0,
+                    quota = 3
+                },
+                skillsetCount = new
+                {
+                    usage = 0,
+                    quota = 15
+                },
+                aliasesCount = new
+                {
+                    usage = 0,
+                    quota = 30
+                },
+                vectorIndexSize = new
+                {
+                    usage = 0L,
+                    quota = 5368709120L
+                }
+            },
+            ["limits"] = new
+            {
+                maxStoragePerIndex = 16106127360L,
+                maxFieldsPerIndex = 1000,
+                maxFieldNestingDepthPerIndex = 10,
+                maxComplexCollectionFieldsPerIndex = 40,
+                maxComplexObjectsInCollectionsPerDocument = 3000
+            }
+        };
+
+        return Ok(stats);
+    }
+}
+

--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ Currently, there is support (to varying degrees) for the following Azure Search 
   * `search` - The actual search query text to pass to the query parser
   * `searchFields` - Comma-delimited list of fields to search
   * `searchMode` - The default boolean operator, either `any` (default) or `all`
+* Get service stats (mostly dummy values)
+  * [Aspire](https://learn.microsoft.com/en-us/dotnet/aspire/azureai/azureai-search-document-integration) for example uses servicestats route as a health check endpoint.
 
 Metadata about indexes are stored as JSON files in the `indexes` folder. 
 Once documents have been added, a subfolder with the index name is created where the Lucene.net index data is stored.


### PR DESCRIPTION
Mostly with dummy values.

At least [Aspire](https://learn.microsoft.com/en-us/dotnet/aspire/azureai/azureai-search-document-integration) libraries use [servicestats-route](https://learn.microsoft.com/en-us/rest/api/searchservice/get-service-statistics/get-service-statistics?view=rest-searchservice-2025-09-01&tabs=HTTP) for health checks.

With this (dummy) implementation there's no need to disable health checks when using the emulator.