### PR TITLE
Support PUT /indexes/{name} for create-or-update (closes #30)

### DIFF
--- a/AzureSearchEmulator.IntegrationTests/EmulatorIntegrationTests.cs
+++ b/AzureSearchEmulator.IntegrationTests/EmulatorIntegrationTests.cs
@@ -320,6 +320,78 @@ public class EmulatorIntegrationTests(EmulatorFactory factory)
     }
 
     [Fact]
+    public async Task CreateOrUpdateIndex_WhenIndexDoesNotExist_ShouldCreate()
+    {
+        // Arrange
+        const string indexName = "test-createorupdate-create";
+        var indexClient = factory.CreateSearchIndexClient();
+
+        // Ensure a clean slate
+        try
+        {
+            await indexClient.DeleteIndexAsync(indexName);
+        }
+        catch (Azure.RequestFailedException ex) when (ex.Status == 404)
+        {
+            // expected
+        }
+
+        var index = new SearchIndex(indexName)
+        {
+            Fields =
+            [
+                new SearchField(nameof(Product.Id), SearchFieldDataType.String) { IsKey = true, IsStored = true, IsSearchable = true, IsFilterable = true },
+                new SearchField(nameof(Product.Name), SearchFieldDataType.String) { IsSearchable = true, IsStored = true }
+            ]
+        };
+
+        // Act - PUT to a non-existent index should create it
+        var result = await indexClient.CreateOrUpdateIndexAsync(index);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(indexName, result.Value.Name);
+
+        var retrieved = await indexClient.GetIndexAsync(indexName);
+        Assert.NotNull(retrieved);
+        Assert.Equal(indexName, retrieved.Value.Name);
+        Assert.Equal(2, retrieved.Value.Fields.Count);
+
+        // Cleanup
+        await indexClient.DeleteIndexAsync(indexName);
+    }
+
+    [Fact]
+    public async Task CreateOrUpdateIndex_WhenIndexExists_ShouldUpdateSchema()
+    {
+        // Arrange
+        const string indexName = "test-createorupdate-update";
+        var indexClient = factory.CreateSearchIndexClient();
+
+        await CreateIndexAsync(indexClient, indexName);
+
+        // Pull the current index and add a backward-compatible field
+        var existing = (await indexClient.GetIndexAsync(indexName)).Value;
+        var originalFieldCount = existing.Fields.Count;
+
+        existing.Fields.Add(new SearchField("Tags", SearchFieldDataType.String) { IsFilterable = true, IsStored = true });
+
+        // Act - PUT on an existing index should update its schema
+        var result = await indexClient.CreateOrUpdateIndexAsync(existing);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(indexName, result.Value.Name);
+
+        var retrieved = await indexClient.GetIndexAsync(indexName);
+        Assert.Equal(originalFieldCount + 1, retrieved.Value.Fields.Count);
+        Assert.Contains(retrieved.Value.Fields, f => f.Name == "Tags");
+
+        // Cleanup
+        await indexClient.DeleteIndexAsync(indexName);
+    }
+
+    [Fact]
     public async Task DeleteIndex_ShouldSucceed()
     {
         const string indexName = "test-delete-index";

--- a/AzureSearchEmulator/Controllers/IndexesController.cs
+++ b/AzureSearchEmulator/Controllers/IndexesController.cs
@@ -64,6 +64,47 @@ public class IndexesController(
         return Created(index);
     }
 
+    [HttpPut]
+    [Route("indexes({key})")]
+    [Route("indexes/{key}")]
+    public async Task<IActionResult> Put(string key)
+    {
+        // Strip quotes that may be captured from OData-style URLs
+        key = key.Trim('\'');
+
+        // HACK.PI: For some reason, having this as a parameter with [FromBody] fails to deserialize properly.
+        using var sr = new StreamReader(Request.Body);
+        var indexJson = await sr.ReadToEndAsync();
+        var index = JsonSerializer.Deserialize<SearchIndex>(indexJson, jsonSerializerOptions);
+
+        if (index == null || !ModelState.IsValid)
+        {
+            return BadRequest(ModelState);
+        }
+
+        if (!string.Equals(index.Name, key, StringComparison.OrdinalIgnoreCase))
+        {
+            ModelState.AddModelError(nameof(index.Name), "The index name in the request body must match the name in the URL.");
+            return BadRequest(ModelState);
+        }
+
+        var existing = await searchIndexRepository.Get(key);
+
+        if (existing == null)
+        {
+            await searchIndexRepository.Create(index);
+            return Created(index);
+        }
+
+        await searchIndexRepository.Update(index);
+
+        // Clear cached Lucene resources so schema changes take effect
+        luceneIndexReaderFactory.ClearCachedReader(index.Name);
+        luceneDirectoryFactory.ClearCachedDirectory(index.Name);
+
+        return Ok(index);
+    }
+
     [HttpDelete]
     [Route("indexes({key})")]
     [Route("indexes/{key}")]

--- a/AzureSearchEmulator/Controllers/IndexesController.cs
+++ b/AzureSearchEmulator/Controllers/IndexesController.cs
@@ -72,7 +72,7 @@ public class IndexesController(
         // Strip quotes that may be captured from OData-style URLs
         key = key.Trim('\'');
 
-        // HACK.PI: For some reason, having this as a parameter with [FromBody] fails to deserialize properly.
+        // HACK.JS: For some reason, having this as a parameter with [FromBody] fails to deserialize properly.
         using var sr = new StreamReader(Request.Body);
         var indexJson = await sr.ReadToEndAsync();
         var index = JsonSerializer.Deserialize<SearchIndex>(indexJson, jsonSerializerOptions);

--- a/AzureSearchEmulator/Repositories/FileSearchIndexRepository.cs
+++ b/AzureSearchEmulator/Repositories/FileSearchIndexRepository.cs
@@ -62,6 +62,20 @@ public class FileSearchIndexRepository(JsonSerializerOptions jsonSerializerOptio
         return WriteAllTextAsync(file, json);
     }
 
+    public Task Update(SearchIndex index)
+    {
+        if (!Directory.Exists(_options.IndexesDirectory))
+        {
+            Directory.CreateDirectory(_options.IndexesDirectory);
+        }
+
+        string file = GetIndexFileName(index.Name);
+
+        string json = JsonSerializer.Serialize(index, jsonSerializerOptions);
+
+        return WriteAllTextAsync(file, json);
+    }
+
     public Task<bool> Delete(SearchIndex index)
     {
         if (!Directory.Exists(_options.IndexesDirectory))

--- a/AzureSearchEmulator/Repositories/ISearchIndexRepository.cs
+++ b/AzureSearchEmulator/Repositories/ISearchIndexRepository.cs
@@ -10,5 +10,7 @@ public interface ISearchIndexRepository
 
     Task Create(SearchIndex index);
 
+    Task Update(SearchIndex index);
+
     Task<bool> Delete(SearchIndex index);
 }


### PR DESCRIPTION
## Summary
- Adds a `PUT /indexes/{name}` handler to `IndexesController` with Azure-style create-or-update semantics: creates the index when absent (returns `201 Created`) and overwrites the schema when present (returns `200 OK`). This unblocks `SearchIndexClient.CreateOrUpdateIndexAsync(...)` from the Azure SDK, which previously got `405 Method Not Allowed`.
- Validates the URL key matches `index.Name` (case-insensitive) and clears the cached Lucene reader/directory on update so schema changes take effect.
- Adds `Update` to `ISearchIndexRepository` and a file-overwrite implementation in `FileSearchIndexRepository`.
- Adds two integration tests exercising the SDK's `CreateOrUpdateIndexAsync`: one for PUT-creates-new-index and one for PUT-updates-existing-with-added-field.

Closes #30.

## Test plan
- [x] `dotnet build AzureSearchEmulator.sln` — clean
- [x] `dotnet test AzureSearchEmulator.UnitTests` — 108/108 passing
- [x] `dotnet test AzureSearchEmulator.IntegrationTests` — 19/19 passing (17 existing + 2 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)